### PR TITLE
Add pkg-config as a dependency

### DIFF
--- a/crystal.rb
+++ b/crystal.rb
@@ -19,6 +19,7 @@ class Crystal < Formula
 
   depends_on "llvm" => :optional
   depends_on "libpcl" => :recommended
+  depends_on "pkg-config"
 
   def install
     # if build.head?


### PR DESCRIPTION
This was required when doing a fresh install Yosemite.
