### PR TITLE
Fix dependency on old OpenSSL on Mac OS X

### DIFF
--- a/crystal.rb
+++ b/crystal.rb
@@ -22,6 +22,7 @@ class Crystal < Formula
 
   depends_on "llvm" => :optional
   depends_on "libpcl" => :recommended
+  depends_on "openssl"
   depends_on "pkg-config"
 
   def install
@@ -34,8 +35,9 @@ class Crystal < Formula
     # end
 
     script_root = %Q(INSTALL_DIR="#{prefix}")
+    openssl_libdir = %Q(LIBRARY_PATH="#{Formula['openssl'].opt_lib}")
     inreplace('bin/crystal') do |s|
-      s.gsub! /INSTALL_DIR=.+/, script_root
+      s.gsub! /INSTALL_DIR=.+/, [script_root, openssl_libdir].join("\n")
     end
 
     if build.with?('llvm') || Formula["llvm"].installed?


### PR DESCRIPTION
Patches the executable wrapper to include brewed OpenSSL's libdir in  `$LIBRARY_PATH`.

The version of OpenSSL that ships in Mac OS X is pretty ancient (0.9.8).  It doesn't get much love from Apple these days since they deprecated it in favor of Common Crypto.

Consequently, it doesn't support TLS 1.2 leading to some obscure errors. I suspect manastech/crystal#664 is one of them.

Admittedly, it's kind of a hackish way to apply the patch.

[Homebrew Formula Cookbook]: https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Formula-Cookbook.md#formula-cookbook