### PR TITLE
Fix SHA256 sum of binary package in formula

### DIFF
--- a/crystal-lang.rb
+++ b/crystal-lang.rb
@@ -7,7 +7,7 @@ class CrystalLang < Formula
 
   resource "boot" do
     url "https://github.com/manastech/crystal/releases/download/0.9.0/crystal-0.9.0-1-darwin-x86_64.tar.gz"
-    sha256 "5a16826145a846da3548e875cf104bdfc04c35cd6628cf66487de1bfbe9c5faf"
+    sha256 "fd670b01dfa35805c8c57126dabebfe25c0942b673d9b3c6d5116d8b3f5ba53a"
   end
 
   resource "shards" do


### PR DESCRIPTION
The SHA256 used in the `crystal-lang` formula was not properly
updated with the release of 0.9.1 version.

This change attempts to correct that.

Fixes manastech/crystal#1878

Thank you. :heart: :heart: :heart: 
